### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Let's get a remote MCP server up-and-running on Cloudflare Workers complete with OAuth login!
 
+<a href="https://glama.ai/mcp/servers/@salman-khandu/mcp-demo">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@salman-khandu/mcp-demo/badge" alt="Remote Server on Cloudflare MCP server" />
+</a>
+
 ## Develop locally
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [Remote MCP Server on Cloudflare](https://glama.ai/mcp/servers/@salman-khandu/mcp-demo) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@salman-khandu/mcp-demo">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@salman-khandu/mcp-demo/badge" alt="Remote Server on Cloudflare MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.